### PR TITLE
PR workflow labeling and codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Repository policy and ownership
+.github/CODEOWNERS @AlexBurnes
+
+# GitHub automation
+.github/workflows/* @AlexBurnes
+
+# Release / packaging / install paths
+buildtools/* @AlexBurnes
+installers/* @AlexBurnes
+.goreleaser* @AlexBurnes
+conanfile* @AlexBurnes
+CMakeLists.txt @AlexBurnes
+cmake/* @AlexBurnes
+scripts/* @AlexBurnes
+.project.yml @AlexBurnes

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -113,10 +113,28 @@ jobs:
               });
             }
             if (labels.has('high-risk')) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                body: 'This PR modifies high-risk paths (workflow/release/install/build pipeline). Manual maintainer review is required.'
-              });
+               const warningText = 'This PR modifies high-risk paths (workflow/release/install/build pipeline). Manual maintainer review is required.';
+
+               const comments = await github.paginate(
+                 github.rest.issues.listComments,
+                 {
+                   owner: context.repo.owner,
+                   repo: context.repo.repo,
+                   issue_number: pr.number,
+                   per_page: 100
+                 }
+               );
+
+               const alreadyCommented = comments.some(c =>
+                 c.body && c.body.includes('high-risk paths')
+               );
+
+               if (labels.has('high-risk') && !alreadyCommented) {
+                 await github.rest.issues.createComment({
+                   owner: context.repo.owner,
+                   repo: context.repo.repo,
+                   issue_number: pr.number,
+                   body: warningText
+                 });
+               }
             }

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
 
 jobs:
   label-pr:
@@ -53,5 +54,69 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: pr.number,
                 labels
+              });
+            }
+
+  label-risk:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label by changed paths
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                per_page: 100
+              }
+            );
+
+            const names = files.map(f => f.filename);
+
+            const labels = new Set();
+
+            for (const f of names) {
+              if (f === '.github/CODEOWNERS') {
+                labels.add('high-risk');
+                labels.add('policy-change');
+              }
+              if (f.startsWith('.github/workflows/')) {
+                labels.add('high-risk');
+                labels.add('workflow-change');
+              }
+              if (
+                f.startsWith('buildtools/') ||
+                f.startsWith('installers/') ||
+                f.startsWith('cmake/') ||
+                f === 'CMakeLists.txt' ||
+                f.startsWith('conanfile') ||
+                f.startsWith('scripts/') ||
+                f === '.project.yml' ||
+                f.startsWith('.goreleaser')
+              ) {
+                labels.add('high-risk');
+                labels.add('release-path');
+              }
+            }
+
+            if (labels.size > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: [...labels]
+              });
+            }
+            if (labels.has('high-risk')) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: 'This PR modifies high-risk paths (workflow/release/install/build pipeline). Manual maintainer review is required.'
               });
             }


### PR DESCRIPTION
- label PR with high-risk lable if changes touch build, workflow or policy files 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes a `pull_request_target` GitHub Actions workflow and adds `issues: write` permissions, affecting automated labeling/commenting on PRs. Incorrect path matching or permissions could lead to unintended label/comment behavior or security exposure in CI automation.
> 
> **Overview**
> Adds a new `.github/CODEOWNERS` file assigning ownership for policy, workflow, and release/build/install-related paths.
> 
> Extends the `Label PRs` GitHub Action to include `issues: write` and a new `label-risk` job that labels PRs as `high-risk` (plus `policy-change`/`workflow-change`/`release-path`) based on changed file paths, and posts a one-time warning comment when high-risk paths are touched.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 440ffa21cc003783878dffd56e8500bb8e97dd24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->